### PR TITLE
Use `malloc` in `fileHandlerImpl`

### DIFF
--- a/webui/bindings.nim
+++ b/webui/bindings.nim
@@ -225,7 +225,7 @@ proc free*(`ptr`: pointer) {.cdecl, importc: "webui_free".}
   ##  Safely free a buffer allocated by WebUI, for example when using 
   ##  `encode()`.
 
-proc malloc*(size: csize_t) {.cdecl, importc: "webui_malloc".}
+proc malloc*(size: csize_t): pointer {.cdecl, importc: "webui_malloc".}
   ##  Safely allocate memory using the WebUI memory management system.
   ##  It can be safely free using `free()`.
 


### PR DESCRIPTION
As a further work after issue #15 , I think it's our binding developers' responsibility to provide memory safe packages to other developers. So I wrote this very first PR of this project.

1. `string` in Nim may contain '\0', not like null-terminating `cstring`. so
```nim
let str: string = "Hi,\0binary"
assert str.len == 10
assert (cstring str).len == 3
assert $(cstring str) == "Hi," # Anything after '\0' is dropped!
assert (cstring str)[4] == 'b'
```
If `content` that `currHandler` returned contains '\0', it was not processed properly. So I turned to use original string's `len` function. For similar reason, it is required, not optional, to tell WebUI library exact length of the content when content contains nulls.

2. The memory of temporary `cstring` object may be GC'ed unexpectedly before it is used by WebUI library. We may use other mechanism to prevent so, but using `webui_malloc` is encouraged by [WebUI document](https://webui.me/docs/2.4.0/#/c_api?id=files-handler) and seems to be a simpler, easier and safer solution.

2. Return type of `proc malloc*` is missing. Is there something wrong with binding generation mechanism?