### PR TITLE
tooltips change show()

### DIFF
--- a/webui.nim
+++ b/webui.nim
@@ -254,7 +254,7 @@ proc parentProcessId*(window: Window): int =
 proc show*(window: Window; content: string): bool = 
   ## Show a window using embedded HTML, or a file. If the window is already
   ## open, it will be refreshed. 
-  ## Please include <script src="webui.js"></script> in the html
+  ## Please include <script src="webui.js"></script> in the HTML
   ## for proper window communication. Essential for creating
   ## multiple windows. 
   ##
@@ -269,7 +269,7 @@ proc show*(window: Window; content: string): bool =
 
 proc show*(window: Window; content: string; browser: bindings.Browsers): bool =
   ## Same as `show() <#show,Window,string>`_, but with a specific web browser.    
-  ## Please include <script src="webui.js"></script> in the html
+  ## Please include <script src="webui.js"></script> in the HTML
   ## for proper window communication. Essential for creating
   ## multiple windows. 
   ##

--- a/webui.nim
+++ b/webui.nim
@@ -44,11 +44,8 @@ proc exit*() =
 proc setTimeout*(timeout: int) = 
   ## Set the maximum time in seconds to wait for browser to start.
   ## 
-  ## Set `timeout` to `0` or a number >86400 to wait forever. 
-  ## Attention: 
-  ## In this case a crash of the browser window 
-  ## would likely keep the backend open indefinitely.
-  ## 
+  ## Set `timeout` to `0` to wait forever. 
+  ##
   ## :timeout: The maximum time in seconds to wait for browser to start.
   ##           Set to `0` to wait forever.
   

--- a/webui.nim
+++ b/webui.nim
@@ -42,9 +42,11 @@ proc exit*() =
   bindings.exit()
 
 proc setTimeout*(timeout: int) = 
-  ## Set the maximum time in seconds to wait for browser to start
+  ## Set the maximum time in seconds to wait for browser to start.
   ## 
-  ## Set `timeout` to `0` to wait forever.
+  ## Set `timeout` to `0` to wait forever. Attention: 
+  ## In this case a crash of the browser window 
+  ## would likely keep the backend open indefinitely.
   ## 
   ## :timeout: The maximum time in seconds to wait for browser to start.
   ##           Set to `0` to wait forever.
@@ -254,7 +256,10 @@ proc parentProcessId*(window: Window): int =
 proc show*(window: Window; content: string): bool = 
   ## Show a window using embedded HTML, or a file. If the window is already
   ## open, it will be refreshed. 
-  ## 
+  ## Please include <script src="webui.js"></script> in the html
+  ## for proper window response. Essential for creating/opening
+  ## multiple windows. 
+  ##
   ## :window: The window to show `content` in. If the window is already
   ##          shown, the UI will get refreshed in the same window.
   ## :content: The content to show in `window`. Can be a file name, or a
@@ -265,7 +270,10 @@ proc show*(window: Window; content: string): bool =
   bindings.show(csize_t window, cstring content)
 
 proc show*(window: Window; content: string; browser: bindings.Browsers): bool =
-  ## Same as `show() <#show,Window,string>`_, but with a specific web browser.
+  ## Same as `show() <#show,Window,string>`_, but with a specific web browser.    
+  ## Please include <script src="webui.js"></script> in the html
+  ## for proper window response. Essential for creating/opening
+  ## multiple windows. 
   ## 
   ## :window: The window to show `content` in. If the window is already
   ##          shown, the UI will get refreshed in the same window.

--- a/webui.nim
+++ b/webui.nim
@@ -44,7 +44,8 @@ proc exit*() =
 proc setTimeout*(timeout: int) = 
   ## Set the maximum time in seconds to wait for browser to start.
   ## 
-  ## Set `timeout` to `0` to wait forever. Attention: 
+  ## Set `timeout` to `0` or a number >86400 to wait forever. 
+  ## Attention: 
   ## In this case a crash of the browser window 
   ## would likely keep the backend open indefinitely.
   ## 

--- a/webui.nim
+++ b/webui.nim
@@ -255,8 +255,7 @@ proc show*(window: Window; content: string): bool =
   ## Show a window using embedded HTML, or a file. If the window is already
   ## open, it will be refreshed. 
   ## Please include <script src="webui.js"></script> in the HTML
-  ## for proper window communication. Essential for creating
-  ## multiple windows. 
+  ## for proper window communication. 
   ##
   ## :window: The window to show `content` in. If the window is already
   ##          shown, the UI will get refreshed in the same window.
@@ -270,8 +269,7 @@ proc show*(window: Window; content: string): bool =
 proc show*(window: Window; content: string; browser: bindings.Browsers): bool =
   ## Same as `show() <#show,Window,string>`_, but with a specific web browser.    
   ## Please include <script src="webui.js"></script> in the HTML
-  ## for proper window communication. Essential for creating
-  ## multiple windows. 
+  ## for proper window communication. 
   ##
   ## :window: The window to show `content` in. If the window is already
   ##          shown, the UI will get refreshed in the same window.

--- a/webui.nim
+++ b/webui.nim
@@ -255,7 +255,7 @@ proc show*(window: Window; content: string): bool =
   ## Show a window using embedded HTML, or a file. If the window is already
   ## open, it will be refreshed. 
   ## Please include <script src="webui.js"></script> in the html
-  ## for proper window response. Essential for creating/opening
+  ## for proper window communication. Essential for creating
   ## multiple windows. 
   ##
   ## :window: The window to show `content` in. If the window is already
@@ -270,9 +270,9 @@ proc show*(window: Window; content: string): bool =
 proc show*(window: Window; content: string; browser: bindings.Browsers): bool =
   ## Same as `show() <#show,Window,string>`_, but with a specific web browser.    
   ## Please include <script src="webui.js"></script> in the html
-  ## for proper window response. Essential for creating/opening
+  ## for proper window communication. Essential for creating
   ## multiple windows. 
-  ## 
+  ##
   ## :window: The window to show `content` in. If the window is already
   ##          shown, the UI will get refreshed in the same window.
   ## :content: The content to show in `window`. Can be a file name, or a


### PR DESCRIPTION
I changed the tooltips for the Nim bindings, making it clearer that a script and js file should be included in the html for proper window response. As per issue #29.
~~Additionally (as mentioned by another commenter in issue #29), the setTimeout() function controls the general wait times for the backend. I find it important to note that a timeout change will also change the backends response time to the close of the app in case of a browser crash.
Specifically, setting setTimeout(0) should keep the backend running indefinitely in case of a browser crash, which could lead to very unsafe behaviour/multiple backend instances upon restart. (If I understood its behaviour correctly)
Additonally, providing setTimeout with a number greater than 86400 would also lead to the backend waiting forever (see resp. C code). So I added that to the tooltip as well.~~

